### PR TITLE
Support for index column, support for output overwrite for Zscores and OHT, and csv -> tsv.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ confounding effects (present in the data) with::
  python inject_outliers_fzse_pysvdcc.py some-dataset/some-dataset.tsv
 
 That command will produce several files with artificial outliers
-(i.e., original data + outliers). These are CSV files but with a ".txt"
+(i.e., original data + outliers). These are TSV files but with a ".txt"
 extension.
 You can edit that script to change some parameters of the injection
 process: frequency, magnitudes of outliers, whether the outliers
@@ -95,10 +95,10 @@ are present in the data, and ``-z6.00`` indicates that the z-score magnitude
 of the outliers is 6.
 
 The tool will also produce corresponding outlier mask (omask) files which
-are CSV files (again ending with ".txt")
+are TSV files (again ending with ".txt")
 containing information about the exact "coordinates"
 of injected outliers' positions.
-Both types of CSV files contain data matrices that are of the same "dimension"
+Both types of TSV files contain data matrices that are of the same "dimension"
 as the data matrix of some-dataset.tsv, and the outlier mask files
 have all zeros except the "coordinates" of outilers which are 1 or -1
 (depending on the z-score of the outlier).

--- a/README.rst
+++ b/README.rst
@@ -47,14 +47,14 @@ is located.
 You can run the various OutSingle sub-tools
 on your data as follows::
 
- python fast_zscore_estimation.py some-dataset/some-dataset.csv
+ python fast_zscore_estimation.py some-dataset/some-dataset.tsv
 
 That will estimate a simple z-score for the dataset.
 The only parameter that you have to supply
 to ``fast_zscore_estimation.py`` is the path to the dataset file
-(here it's ``some-dataset/some-dataset.csv``).
+(here it's ``some-dataset/some-dataset.tsv``).
 The dataset file should be a tab-separated
-pandas-compatible CSV file containing
+pandas-compatible file containing
 gene expression counts.
 Its index (first column) should
 contain names of genes,
@@ -67,16 +67,16 @@ integer count data.
 After z-score estimation, you can calculate the final
 OutSingle score with::
 
- python optht_svd_zs.py some-dataset/some-dataset-fzse-zs.csv
+ python optht_svd_zs.py some-dataset/some-dataset-fzse-zs.tsv
  
-That will produce a file ``some-dataset/some-dataset-fzse-zs-svd-optht-zs.csv``
+That will produce a file ``some-dataset/some-dataset-fzse-zs-svd-optht-zs.tsv``
 which can be considered as the final OutSingle "outlierness" score
 for the dataset.
 
 You can also inject artificial outliers that are masked by
 confounding effects (present in the data) with::
 
- python inject_outliers_fzse_pysvdcc.py some-dataset/some-dataset.csv
+ python inject_outliers_fzse_pysvdcc.py some-dataset/some-dataset.tsv
 
 That command will produce several files with artificial outliers
 (i.e., original data + outliers). These are CSV files but with a ".txt"
@@ -99,7 +99,7 @@ are CSV files (again ending with ".txt")
 containing information about the exact "coordinates"
 of injected outliers' positions.
 Both types of CSV files contain data matrices that are of the same "dimension"
-as the data matrix of some-dataset.csv, and the outlier mask files
+as the data matrix of some-dataset.tsv, and the outlier mask files
 have all zeros except the "coordinates" of outilers which are 1 or -1
 (depending on the z-score of the outlier).
 
@@ -110,7 +110,7 @@ an OutSingle score for them. E.g.::
  python fast_zscore_estimation.py some-dataset/some-dataset-wo-f1-b-z6.00.txt
  python optht_svd_zs.py some-dataset/some-dataset-wo-f1-b-z6.00-fzse-zs.txt
 
-That will produce a ``some-dataset/some-dataset-wo-f1-b-z6.00-fzse-zs-svd-optht-zs.csv``
+That will produce a ``some-dataset/some-dataset-wo-f1-b-z6.00-fzse-zs-svd-optht-zs.tsv``
 OutSingle score file.
 
 Further info

--- a/fast_zscore_estimation.py
+++ b/fast_zscore_estimation.py
@@ -40,7 +40,7 @@ def get_z_scores(data, l_ji_other__=None):
     return z_scores, l_ji__
 
 
-def run(data_file):
+def run(data_file, overwrite):
     # dl = h.DataLoader(outpyr.settings, data_file)
     # df = dl.data_normalized_sf
     # data_cleaned = df.values.astype(np.float64)
@@ -51,20 +51,22 @@ def run(data_file):
     z_scores, l_ji__ = get_z_scores(data)
     # print(np.any(np.abs(z_scores) > THRESHOLD))
     z_scores, _ = get_z_scores(data_cleaned, l_ji__)
-
     fname = os.path.splitext(data_file)[0] + '-fzse-zs.csv'
-    h.save_dfz_to_csv(pd.DataFrame(z_scores, index=df.index, columns=df.columns), fname)
+    if overwrite:
+        print("--overwrite specified. Overwriting existing output.")
+    h.save_dfz_to_csv(pd.DataFrame(z_scores, index=df.index, columns=df.columns), fname, overwrite)
     return os.path.abspath(fname)
 
 
 def main():
     parser = argparse.ArgumentParser(description='Train model.')
     parser.add_argument('data_file', metavar='data_file', type=str, nargs=1, help='file with count data')
+    parser.add_argument('--overwrite', action='store_true', help='overwrite existing output')
     args = parser.parse_args()
     # print(args.corrected)
     data_file = args.data_file[0]
-
-    run(data_file)
+    overwrite = args.overwrite
+    run(data_file, overwrite)
 
 
 if __name__ == '__main__':

--- a/fast_zscore_estimation.py
+++ b/fast_zscore_estimation.py
@@ -51,7 +51,7 @@ def run(data_file, overwrite):
     z_scores, l_ji__ = get_z_scores(data)
     # print(np.any(np.abs(z_scores) > THRESHOLD))
     z_scores, _ = get_z_scores(data_cleaned, l_ji__)
-    fname = os.path.splitext(data_file)[0] + '-fzse-zs.csv'
+    fname = os.path.splitext(data_file)[0] + '-fzse-zs.tsv'
     if overwrite:
         print("--overwrite specified. Overwriting existing output.")
     h.save_dfz_to_csv(pd.DataFrame(z_scores, index=df.index, columns=df.columns), fname, overwrite)

--- a/helpers.py
+++ b/helpers.py
@@ -29,19 +29,21 @@ def csv_to_df(file_name, dtype=COUNT_INT):
         text = text[1:]
 
     has_index = False
+    index_col = None
     tmp_df = pd.read_csv(StringIO(text), sep='\t', nrows=0)
 
     dtypes = {}
     for idx, column in enumerate(tmp_df.columns):
         if idx == 0 and isinstance(tmp_df.at[idx, column], str):
             has_index = True
+            index_col = column
         dtypes[column] = dtype
 
     if has_index:
         return pd.read_csv(
             StringIO(text),
             sep='\t',
-            index_col=0,
+            index_col=index_col,
             dtype=dtypes,
         )
     else:

--- a/helpers.py
+++ b/helpers.py
@@ -28,18 +28,28 @@ def csv_to_df(file_name, dtype=COUNT_INT):
         # Removing the initial separator, if any, as it makes problems for pd.read_csv
         text = text[1:]
 
+    has_index = False
+    tmp_df = pd.read_csv(StringIO(text), sep='\t', nrows=0)
+
     dtypes = {}
-    for column in pd.read_csv(
-            StringIO(text),
-            sep='\t',
-        nrows=0).columns:
+    for idx, column in enumerate(tmp_df.columns):
+        if idx == 0 and isinstance(tmp_df.at[idx, column], str):
+            has_index = True
         dtypes[column] = dtype
 
-    return pd.read_csv(
-        StringIO(text),
-        sep='\t',
-        dtype=dtypes,
-    )
+    if has_index:
+        return pd.read_csv(
+            StringIO(text),
+            sep='\t',
+            index_col=0,
+            dtype=dtypes,
+        )
+    else:
+        return pd.read_csv(
+            StringIO(text),
+            sep='\t',
+            dtype=dtypes,
+        )
 
 
 def get_size_factors(df):

--- a/helpers.py
+++ b/helpers.py
@@ -95,7 +95,10 @@ def get_size_factors(df):
 
 def save_df_to_csv(data_df, file_name, overwrite=False):
     if not os.path.exists(file_name) or overwrite:
-        data_df.to_csv(file_name, sep='\t')
+        if data_df.index.tolist() == list(range(data_df.shape[0])):
+            data_df.to_csv(file_name, sep='\t', index=False)
+        else:
+            data_df.to_csv(file_name, sep='\t')
 
         with open(file_name, 'r') as f:
             # Removing the initial separator, as it makes problems for pd.read_csv

--- a/optht_svd_zs.py
+++ b/optht_svd_zs.py
@@ -36,7 +36,7 @@ def main():
 
 def process(data_file, overwrite):
     out_basename = os.path.splitext(data_file)[0] + '-svd-optht'
-    out_name = out_basename + '-zs.csv'
+    out_name = out_basename + '-zs.tsv'
     if os.path.isfile(out_name) and not overwrite:
         print('File', out_name, 'already exists.')
         return out_name
@@ -71,14 +71,14 @@ def process(data_file, overwrite):
 
         # _data2 = standardize(data - data_new, axis=None)
         if transpose:
-            # h.save_dfz_to_csv(pd.DataFrame(data_new.transpose(), index=df.index, columns=df.columns), out_basename + '-signal-t-zs.csv')
-            # h.save_dfz_to_csv(pd.DataFrame((data - data_new).transpose(), index=df.index, columns=df.columns), out_basename + '-won-t-zs.csv')
-            h.save_dfz_to_csv(pd.DataFrame(_data2.transpose(), index=df.index, columns=df.columns), out_basename + '-t-zs.csv', overwrite)
+            # h.save_dfz_to_csv(pd.DataFrame(data_new.transpose(), index=df.index, columns=df.columns), out_basename + '-signal-t-zs.tsv')
+            # h.save_dfz_to_csv(pd.DataFrame((data - data_new).transpose(), index=df.index, columns=df.columns), out_basename + '-won-t-zs.tsv')
+            h.save_dfz_to_csv(pd.DataFrame(_data2.transpose(), index=df.index, columns=df.columns), out_basename + '-t-zs.tsv', overwrite)
         else:
-            # h.save_dfz_to_csv(pd.DataFrame(data_new, index=df.index, columns=df.columns), out_basename + '-signal-zs.csv')
-            # h.save_dfz_to_csv(pd.DataFrame(data - data_new, index=df.index, columns=df.columns), out_basename + '-won-zs.csv')
+            # h.save_dfz_to_csv(pd.DataFrame(data_new, index=df.index, columns=df.columns), out_basename + '-signal-zs.tsv')
+            # h.save_dfz_to_csv(pd.DataFrame(data - data_new, index=df.index, columns=df.columns), out_basename + '-won-zs.tsv')
             h.save_dfz_to_csv(pd.DataFrame(_data2, index=df.index, columns=df.columns), out_name, overwrite)
-        # h.save_dfz_to_csv(pd.DataFrame(zs_outrider_ideal__, index=df.index, columns=df.columns), out_basename + '-ori-zs.csv')
+        # h.save_dfz_to_csv(pd.DataFrame(zs_outrider_ideal__, index=df.index, columns=df.columns), out_basename + '-ori-zs.tsv')
 
     return out_name
 

--- a/optht_svd_zs.py
+++ b/optht_svd_zs.py
@@ -26,18 +26,23 @@ def svd(data, U, s, VT, s_dimension):
 def main():
     parser = argparse.ArgumentParser(description='Train model.')
     parser.add_argument('data_file', metavar='data_file', type=str, nargs=1, help='file with count data')
+    parser.add_argument('--overwrite', action='store_true', help='overwrite existing output')
     args = parser.parse_args()
     # print(args.corrected)
     data_file = args.data_file[0]
-    process(data_file)
+    overwrite = args.overwrite
+    process(data_file, overwrite)
 
 
-def process(data_file):
+def process(data_file, overwrite):
     out_basename = os.path.splitext(data_file)[0] + '-svd-optht'
     out_name = out_basename + '-zs.csv'
-    if os.path.isfile(out_name):
+    if os.path.isfile(out_name) and not overwrite:
         print('File', out_name, 'already exists.')
         return out_name
+    elif os.path.isfile(out_name) and overwrite:
+        print("--overwrite specified. Overwriting existing output.")
+
     df = h.csv_to_df(data_file, dtype=np.float64)
 
     data_original = h.clean_zs(df.values)
@@ -68,11 +73,11 @@ def process(data_file):
         if transpose:
             # h.save_dfz_to_csv(pd.DataFrame(data_new.transpose(), index=df.index, columns=df.columns), out_basename + '-signal-t-zs.csv')
             # h.save_dfz_to_csv(pd.DataFrame((data - data_new).transpose(), index=df.index, columns=df.columns), out_basename + '-won-t-zs.csv')
-            h.save_dfz_to_csv(pd.DataFrame(_data2.transpose(), index=df.index, columns=df.columns), out_basename + '-t-zs.csv')
+            h.save_dfz_to_csv(pd.DataFrame(_data2.transpose(), index=df.index, columns=df.columns), out_basename + '-t-zs.csv', overwrite)
         else:
             # h.save_dfz_to_csv(pd.DataFrame(data_new, index=df.index, columns=df.columns), out_basename + '-signal-zs.csv')
             # h.save_dfz_to_csv(pd.DataFrame(data - data_new, index=df.index, columns=df.columns), out_basename + '-won-zs.csv')
-            h.save_dfz_to_csv(pd.DataFrame(_data2, index=df.index, columns=df.columns), out_name)
+            h.save_dfz_to_csv(pd.DataFrame(_data2, index=df.index, columns=df.columns), out_name, overwrite)
         # h.save_dfz_to_csv(pd.DataFrame(zs_outrider_ideal__, index=df.index, columns=df.columns), out_basename + '-ori-zs.csv')
 
     return out_name


### PR DESCRIPTION
# CHANGE 1: Index
Currently, there is no support for importing data tables containing a column with gene names as index. As the documents state: " The dataset file should be a tab-separated pandas-compatible CSV file containing gene expression counts. Its index (first column) should contain names of genes, while its columns header (first row) should contain the names of samples that the counts were sequenced from.". However, running the code with an index column led to an error of the inability to coerce gene names to float objects.
Since the documentation assumes an index, the presence of an index column is automatically inferred. `helpers.csv_to_df` is changed to allow for indexing by checking the first value of the first column. If it is a `str` object, it is assumed to be the index. 

# CHANGE 2: Overwrite
Currently, if a file already exists, then no new output is written. The changes to `fast_zscore_estimation.py` and `optht_svd_zs.py` allow an `--overwrite` flag, which, if present, allows the output to be overwritten. `helpers.save_df_to_csv` and `helpers.save_dfz_to_csv` are modified to intake the overwrite flag and overwrite existing data if present.

# CHANGE 3: CSV to TSV
The documentation mentions "CSV" files, yet the input and output of many scripts are in a tab-separated format. The documentation and output extentions have been changed to "TSV" and `.tsv`, respectively, to reflect the tab-separated value format. 

These changes were tested against the current code version against the new code version, including tables with and without gene name indices, and the results were identical between versions. 